### PR TITLE
Add FreeBSD support to this formula

### DIFF
--- a/fail2ban/config.sls
+++ b/fail2ban/config.sls
@@ -3,7 +3,7 @@
 include:
   - fail2ban
 
-/etc/fail2ban/fail2ban.local:
+{{ fail2ban.prefix }}/etc/fail2ban/fail2ban.local:
   file.managed:
     - source: salt://fail2ban/files/fail2ban_conf.template
     - template: jinja
@@ -13,7 +13,7 @@ include:
         config:
             Definition: {{ fail2ban.config|yaml }}
 
-/etc/fail2ban/jail.local:
+{{ fail2ban.prefix }}/etc/fail2ban/jail.local:
   file.managed:
     - source: salt://fail2ban/files/fail2ban_conf.template
     - template: jinja
@@ -23,7 +23,7 @@ include:
         config: {{ fail2ban.jails|yaml }}
 
 {% for name, config in fail2ban.actions|dictsort %}
-/etc/fail2ban/action.d/{{ name }}.conf:
+{{ fail2ban.prefix }}/etc/fail2ban/action.d/{{ name }}.conf:
   file.managed:
     - source: salt://fail2ban/files/fail2ban_conf.template
     - template: jinja
@@ -34,7 +34,7 @@ include:
 {% endfor %}
 
 {% for name, config in fail2ban.filters|dictsort %}
-/etc/fail2ban/filter.d/{{ name }}.conf:
+{{ fail2ban.prefix }}/etc/fail2ban/filter.d/{{ name }}.conf:
   file.managed:
     - source: salt://fail2ban/files/fail2ban_conf.template
     - template: jinja

--- a/fail2ban/map.jinja
+++ b/fail2ban/map.jinja
@@ -2,6 +2,7 @@
     'Debian': {
         'package': 'fail2ban',
         'service': 'fail2ban',
+        'prefix': '',
         'config': {},
         'jails': {},
         'actions': {},
@@ -10,6 +11,7 @@
     'FreeBSD': {
         'package': 'py27-fail2ban',
         'service': 'fail2ban',
+        'prefix': '/usr/local',
         'config': {},
         'jails': {},
         'actions': {},
@@ -18,6 +20,7 @@
     'Gentoo': {
         'package': 'net-analyzer/fail2ban',
         'service': 'fail2ban',
+        'prefix': '',
         'config': {},
         'jails': {},
         'actions': {},
@@ -26,6 +29,7 @@
     'RedHat': {
         'package': 'fail2ban',
         'service': 'fail2ban',
+        'prefix': '',
         'config': {},
         'jails': {},
         'actions': {},

--- a/fail2ban/map.jinja
+++ b/fail2ban/map.jinja
@@ -7,6 +7,14 @@
         'actions': {},
         'filters': {},
     },
+    'FreeBSD': {
+        'package': 'py27-fail2ban',
+        'service': 'fail2ban',
+        'config': {},
+        'jails': {},
+        'actions': {},
+        'filters': {},
+    },
     'Gentoo': {
         'package': 'net-analyzer/fail2ban',
         'service': 'fail2ban',


### PR DESCRIPTION
The necessary changes are pretty simple.  Since the fail2ban package installs to `/usr/local` on FreeBSD, I chose to prefix the file paths in the `fail2ban.config` SLS instead of something more sophisticated.