### PR TITLE
Use the extension .local instead of .conf

### DIFF
--- a/fail2ban/config.sls
+++ b/fail2ban/config.sls
@@ -23,7 +23,7 @@ include:
         config: {{ fail2ban.jails|yaml }}
 
 {% for name, config in fail2ban.actions|dictsort %}
-{{ fail2ban.prefix }}/etc/fail2ban/action.d/{{ name }}.conf:
+{{ fail2ban.prefix }}/etc/fail2ban/action.d/{{ name }}.local:
   file.managed:
     - source: salt://fail2ban/files/fail2ban_conf.template
     - template: jinja
@@ -34,7 +34,7 @@ include:
 {% endfor %}
 
 {% for name, config in fail2ban.filters|dictsort %}
-{{ fail2ban.prefix }}/etc/fail2ban/filter.d/{{ name }}.conf:
+{{ fail2ban.prefix }}/etc/fail2ban/filter.d/{{ name }}.local:
   file.managed:
     - source: salt://fail2ban/files/fail2ban_conf.template
     - template: jinja


### PR DESCRIPTION
Write our site-local configuration to .local files to keep .conf
strictly for files that come from the package management system