### PR TITLE
Prevent creation of empty .local files

### DIFF
--- a/fail2ban/config.sls
+++ b/fail2ban/config.sls
@@ -4,6 +4,7 @@ include:
   - fail2ban
 
 {{ fail2ban.prefix }}/etc/fail2ban/fail2ban.local:
+{% if fail2ban.config %}
   file.managed:
     - source: salt://fail2ban/files/fail2ban_conf.template
     - template: jinja
@@ -12,8 +13,12 @@ include:
     - context:
         config:
             Definition: {{ fail2ban.config|yaml }}
+{% else %}
+  file.absent: []
+{% endif %}
 
 {{ fail2ban.prefix }}/etc/fail2ban/jail.local:
+{% if fail2ban.jails %}
   file.managed:
     - source: salt://fail2ban/files/fail2ban_conf.template
     - template: jinja
@@ -21,6 +26,9 @@ include:
       - service: {{ fail2ban.service }}
     - context:
         config: {{ fail2ban.jails|yaml }}
+{% else %}
+  file.absent: []
+{% endif %}
 
 {% for name, config in fail2ban.actions|dictsort %}
 {{ fail2ban.prefix }}/etc/fail2ban/action.d/{{ name }}.local:


### PR DESCRIPTION
There is no need to create the fail2ban.local and jail.local files if no pillar data has been defined.