### PR TITLE
Reload service if empty .local files are removed

### DIFF
--- a/fail2ban/config.sls
+++ b/fail2ban/config.sls
@@ -8,27 +8,27 @@ include:
   file.managed:
     - source: salt://fail2ban/files/fail2ban_conf.template
     - template: jinja
-    - watch_in:
-      - service: {{ fail2ban.service }}
     - context:
         config:
             Definition: {{ fail2ban.config|yaml }}
 {% else %}
-  file.absent: []
+  file.absent:
 {% endif %}
+    - watch_in:
+      - service: {{ fail2ban.service }}
 
 {{ fail2ban.prefix }}/etc/fail2ban/jail.local:
 {% if fail2ban.jails %}
   file.managed:
     - source: salt://fail2ban/files/fail2ban_conf.template
     - template: jinja
-    - watch_in:
-      - service: {{ fail2ban.service }}
     - context:
         config: {{ fail2ban.jails|yaml }}
 {% else %}
-  file.absent: []
+  file.absent:
 {% endif %}
+    - watch_in:
+      - service: {{ fail2ban.service }}
 
 {% for name, config in fail2ban.actions|dictsort %}
 {{ fail2ban.prefix }}/etc/fail2ban/action.d/{{ name }}.local:


### PR DESCRIPTION
If the fail2ban.local or jail.local files are removed because they no longer contain any settings, the fail2ban service needs to be restarted to pick up the removal of these settings.