### PR TITLE
Clean map.jinja

### DIFF
--- a/fail2ban/init.sls
+++ b/fail2ban/init.sls
@@ -3,9 +3,8 @@
 fail2ban:
   pkg.installed:
     - name: {{ fail2ban.package }}
-  service:
+  service.running:
     - name: {{ fail2ban.service }}
-    - running
     - enable: True
     - require:
       - pkg: fail2ban

--- a/fail2ban/map.jinja
+++ b/fail2ban/map.jinja
@@ -1,8 +1,5 @@
 {% set fail2ban = salt['grains.filter_by']({
-    'Debian': {
-        'package': 'fail2ban',
-        'service': 'fail2ban',
-        'prefix': '',
+    'common': {
         'config': {},
         'jails': {},
         'actions': {},
@@ -12,36 +9,15 @@
         'package': 'py27-fail2ban',
         'service': 'fail2ban',
         'prefix': '/usr/local',
-        'config': {},
-        'jails': {},
-        'actions': {},
-        'filters': {},
     },
     'Gentoo': {
         'package': 'net-analyzer/fail2ban',
         'service': 'fail2ban',
         'prefix': '',
-        'config': {},
-        'jails': {},
-        'actions': {},
-        'filters': {},
     },
-    'RedHat': {
+    'default': {
         'package': 'fail2ban',
         'service': 'fail2ban',
         'prefix': '',
-        'config': {},
-        'jails': {},
-        'actions': {},
-        'filters': {},
     },
-    'Arch': {
-        'package': 'fail2ban',
-        'service': 'fail2ban',
-        'prefix': '',
-        'config': {},
-        'jails': {},
-        'actions': {},
-        'filters': {},
-    },
-}, merge=salt['pillar.get']('fail2ban:lookup')) %}
+}, merge=salt['pillar.get']('fail2ban:lookup'), base='common') %}


### PR DESCRIPTION
Since most of the keys are the same the `grains.filter_by` function allows for a `'default'` key for all non-matched `os_family` and a `base` lookup_dict key for all the keys that are the same for every distribution.
I also changed the state declaration to use the suggested dot notation. 