### PR TITLE
Fix indenting, actions cannot be list

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,37 +1,34 @@
 fail2ban:
-    lookup:
-        config:
-            loglevel: 2
-            ignoreip: 127.0.0.1/8
-            bantime: 600
-            maxretry: 3
-            backend: auto
-        jails:
-            ssh:
-                action:
-                    - iptables[name=SSH, port=ssh, protocol=tcp]
-                enabled: 'true'
-                filter: sshd
-                logpath: /var/log/auth.log
-                maxretry: 6
-                port: ssh
-            ssh_ddos:
-                action:
-                    - iptables[name=SSH, port=ssh, protocol=tcp]
-                enabled: 'true'
-                filter: sshd-ddos
-                logpath: /var/log/auth.log
-                maxretry: 6
-                port: ssh
-            nginx-noscript:
-                action:
-                    - iptables-multiport[name=NoScript, port="http,https"]
-                enabled: 'true'
-                filter: nginx-noscript
-                logpath: /var/log/nginx*/*access*.log
-                maxretry: 6
-                port: http,https
-        filters:
-            nginx-noscript:
-                Definition:
-                    failregex: <HOST>.*(GET|POST).*(\.php|\.asp|\.exe|\.pl|\.cgi|\.scgi).*
+  lookup:
+    config:
+      loglevel: 2
+      ignoreip: 127.0.0.1/8
+      bantime: 600
+      maxretry: 3
+      backend: auto
+    jails:
+      ssh:
+        actions: iptables[name=SSH, port=ssh, protocol=tcp]
+        enabled: 'true'
+        filter: sshd
+        logpath: /var/log/auth.log
+        maxretry: 6
+        port: ssh
+      ssh_ddos:
+        action: iptables[name=SSH, port=ssh, protocol=tcp]
+        enabled: 'true'
+        filter: sshd-ddos
+        logpath: /var/log/auth.log
+        maxretry: 6
+        port: ssh
+      nginx-noscript:
+        action: iptables-multiport[name=NoScript, port="http,https"]
+        enabled: 'true'
+        filter: nginx-noscript
+        logpath: /var/log/nginx*/*access*.log
+        maxretry: 6
+        port: http,https
+    filters:
+      nginx-noscript:
+        Definition:
+          failregex: <HOST>.*(GET|POST).*(\.php|\.asp|\.exe|\.pl|\.cgi|\.scgi).*


### PR DESCRIPTION
I fixed all of the indenting to make it two spaces, and modified the `action` section to be a single item instead of a list, having it as a list breaks the run.