### PR TITLE
Fix pillar example with proper error level

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,7 +1,7 @@
 fail2ban:
   lookup:
     config:
-      loglevel: 2
+      loglevel: ERROR
       ignoreip: 127.0.0.1/8
       bantime: 600
       maxretry: 3


### PR DESCRIPTION
2 is not accepted as a parameter!
It returns this error during the startup:

 fail2ban-client[2925]: ERROR  NOK: ('Invalid log level',)
