### PR TITLE
Added new ng states

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ Keep in mind that in ng states ``lookup``, ``config``, ``jails``, ``actions`` an
       actions:
       filters:
 
-Keep in mind also that in ng states change, the syntax for the actions and filters adding a new `config` section:
+Keep in mind also that in ng states change the syntax for the actions and filters adding a new `config` section and `enabled` option (optional):
 
 .. code-block:: yaml
 
@@ -92,12 +92,33 @@ Keep in mind also that in ng states change, the syntax for the actions and filte
             Definition:
                 actionban:
                 actionunban:
+            Init:
+                whatever:
       filters:
         name-of-filter:
           enabled: True/False # OPTIONAL
           config:
             Definition:
                 failregex:
+
+It is also possible to specify the source file for config, jails, actions and filters instead of using the template:
+
+.. code-block:: yaml
+
+  fail2ban:
+    ng:
+      config:
+        source_path: salt://path-to-fail2ban-config-file
+      jails:
+        source_path: salt://path-to-fail2ban-config-file
+      actions:
+        name-of-action:
+          config:
+            source_path: salt://path-to-action-file
+      filters:
+        name-of-filter:
+          config:
+            source_path: salt://path-to-filter-file
 
 ``fail2ban.ng.service``
 -----------------------

--- a/README.rst
+++ b/README.rst
@@ -43,3 +43,69 @@ The ``fail2ban.config`` state also populates the ``jail.local``, ``fail2ban.loca
 Gotchas
 =======
 In the ``pillar.example``, note that the iptable action uses ``port=ssh`` (lowercase), not ``port=SSH`` (uppercase).
+
+Next-generation, alternate approach
+===================================
+
+The following states provide an alternate approach to managing fail2ban. Tested in Ubuntu 14/16 and CentOS 6/7.
+
+.. contents::
+    :local:
+
+``fail2ban.ng``
+---------------
+
+Meta state for inclusion of all ng states.
+
+``fail2ban.ng.install``
+-----------------------
+
+Install the ``fail2ban`` package.
+
+``fail2ban.ng.config``
+----------------------
+
+Configure fail2ban creating a ``jail.local`` file based on pillar data that overrid ``jail.conf``. It also creates a ``file.local`` per action/filter. Either in jails, actions or filters is possible to setup a ``source_path`` options to upload your configuration directly (see ``pillar.example``). It is also possible to remove either actions or filters setting up ``enabled: False`` in it section (see ``pillar.example``).
+
+Keep in mind that in ng states ``lookup``, ``config``, ``jails``, ``actions`` and ``filters`` are at the same level (in the old states, all the sections are under ``lookup``:
+
+.. code-block:: yaml
+
+  fail2ban:
+    ng:
+      lookup:
+      config:
+      jails:
+      actions:
+      filters:
+
+Keep in mind also that in ng states change, the syntax for the actions and filters adding a new `config` section:
+
+.. code-block:: yaml
+
+  fail2ban:
+    ng:
+      actions:
+        name-of-action:
+          enabled: True/False # OPTIONAL
+          config:
+            Definition:
+                actionban:
+                actionunban:
+      filters:
+        name-of-filter:
+          enabled: True/False # OPTIONAL
+          config:
+            Definition:
+                failregex:
+
+``fail2ban.ng.service``
+-----------------------
+
+Manage fail2ban service. It is also possible to disable the service using the following pillar configuration:
+
+.. code-block:: yaml
+
+  fail2ban:
+    ng:
+      enabled: False

--- a/fail2ban/ng/config.sls
+++ b/fail2ban/ng/config.sls
@@ -19,9 +19,11 @@ fail2ban.ng.config.fail2ban:
         - group: {{ fail2ban.group|default('root') }}
         - mode: '{{ fail2ban.mode|default("644")}}'
         - template: jinja
+    {% if fail2ban.config.source_path is not defined %}
         - context:
             config:
                 Definition: {{ fail2ban.config|yaml }}
+    {% endif %}
 {% else %}
     file.absent:
         - name: {{ fail2ban.prefix }}/etc/fail2ban/fail2ban.local
@@ -45,8 +47,10 @@ fail2ban.ng.config.jails:
         - group: {{ fail2ban.group|default('root') }}
         - mode: '{{ fail2ban.mode|default("644")}}'
         - template: jinja
+    {% if fail2ban.jails.source_path is not defined %}
         - context:
             config: {{ fail2ban.jails|yaml }}
+    {% endif %}
 {% else %}
     file.absent:
 {% endif %}
@@ -55,8 +59,8 @@ fail2ban.ng.config.jails:
 
 {% for name, options in fail2ban.actions|dictsort %}
 
-{% if fail2ban.actions[name].source_path is defined %}
-{% set fail2ban_actions = fail2ban.actions[name].source_path %}
+{% if options.config.source_path is defined %}
+{% set fail2ban_actions = options.config.source_path %}
 {% else %}
 {% set fail2ban_actions = 'salt://fail2ban/ng/files/config.jinja' %}
 {% endif %}
@@ -72,8 +76,10 @@ fail2ban.ng.config.action.{{ name }}:
         - template: jinja
         - watch_in:
             - service: {{ fail2ban.service }}
+    {% if options.config.source_path is not defined %}
         - context:
             config: {{ options.config|yaml }}
+    {% endif %}
 {% elif 'enabled' in options and not options.enabled %}
     file.absent:
         - name: {{ fail2ban.prefix }}/etc/fail2ban/action.d/{{ name }}.local
@@ -82,8 +88,8 @@ fail2ban.ng.config.action.{{ name }}:
 
 {% for name, options in fail2ban.filters|dictsort %}
 
-{% if fail2ban.filters[name].source_path is defined %}
-{% set fail2ban_filters = fail2ban.filters[name].source_path %}
+{% if options.config.source_path is defined %}
+{% set fail2ban_filters = options.config.source_path %}
 {% else %}
 {% set fail2ban_filters = 'salt://fail2ban/ng/files/config.jinja' %}
 {% endif %}
@@ -99,8 +105,10 @@ fail2ban.ng.config.filter.{{ name }}:
         - template: jinja
         - watch_in:
           - service: {{ fail2ban.service }}
+    {% if options.config.source_path is not defined %}
         - context:
             config: {{ options.config|yaml }}
+    {% endif %}
 {% elif 'enabled' in options and not options.enabled %}
     file.absent:
         - name: {{ fail2ban.prefix }}/etc/fail2ban/filter.d/{{ name }}.local

--- a/fail2ban/ng/config.sls
+++ b/fail2ban/ng/config.sls
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+{% from "fail2ban/ng/map.jinja" import fail2ban with context %}
+
+fail2ban.ng.config.fail2ban:
+{% if fail2ban.config is defined %}
+
+{% if fail2ban.config.source_path is defined %}
+{% set fail2ban_config = fail2ban.config.source_path %}
+{% else %}
+{% set fail2ban_config = 'salt://fail2ban/ng/files/config.jinja' %}
+{% endif %}
+
+    file.managed:
+        - name: {{ fail2ban.prefix }}/etc/fail2ban/fail2ban.local
+        - source: {{ fail2ban_config }}
+        - user: {{ fail2ban.user|default('root') }}
+        - group: {{ fail2ban.group|default('root') }}
+        - mode: '{{ fail2ban.mode|default("644")}}'
+        - template: jinja
+        - context:
+            config:
+                Definition: {{ fail2ban.config|yaml }}
+{% else %}
+    file.absent:
+        - name: {{ fail2ban.prefix }}/etc/fail2ban/fail2ban.local
+{% endif %}
+        - watch_in:
+            - service: {{ fail2ban.service }}
+
+fail2ban.ng.config.jails:
+{% if fail2ban.jails is defined %}
+
+{% if fail2ban.jails.source_path is defined %}
+{% set fail2ban_jails = fail2ban.jails.source_path %}
+{% else %}
+{% set fail2ban_jails = 'salt://fail2ban/ng/files/config.jinja' %}
+{% endif %}
+
+    file.managed:
+        - name: {{ fail2ban.prefix }}/etc/fail2ban/jail.local
+        - source: {{ fail2ban_jails }}
+        - user: {{ fail2ban.user|default('root') }}
+        - group: {{ fail2ban.group|default('root') }}
+        - mode: '{{ fail2ban.mode|default("644")}}'
+        - template: jinja
+        - context:
+            config: {{ fail2ban.jails|yaml }}
+{% else %}
+    file.absent:
+{% endif %}
+        - watch_in:
+            - service: {{ fail2ban.service }}
+
+{% for name, options in fail2ban.actions|dictsort %}
+
+{% if fail2ban.actions[name].source_path is defined %}
+{% set fail2ban_actions = fail2ban.actions[name].source_path %}
+{% else %}
+{% set fail2ban_actions = 'salt://fail2ban/ng/files/config.jinja' %}
+{% endif %}
+
+fail2ban.ng.config.action.{{ name }}:
+{% if ( 'enabled' in options and options.enabled ) or ('enabled' not in options ) %}
+    file.managed:
+        - name: {{ fail2ban.prefix }}/etc/fail2ban/action.d/{{ name }}.local
+        - source: {{ fail2ban_actions }}
+        - user: {{ fail2ban.user|default('root') }}
+        - group: {{ fail2ban.group|default('root') }}
+        - mode: '{{ fail2ban.mode|default("644")}}'
+        - template: jinja
+        - watch_in:
+            - service: {{ fail2ban.service }}
+        - context:
+            config: {{ options.config|yaml }}
+{% elif 'enabled' in options and not options.enabled %}
+    file.absent:
+        - name: {{ fail2ban.prefix }}/etc/fail2ban/action.d/{{ name }}.local
+{% endif %}
+{% endfor %}
+
+{% for name, options in fail2ban.filters|dictsort %}
+
+{% if fail2ban.filters[name].source_path is defined %}
+{% set fail2ban_filters = fail2ban.filters[name].source_path %}
+{% else %}
+{% set fail2ban_filters = 'salt://fail2ban/ng/files/config.jinja' %}
+{% endif %}
+
+fail2ban.ng.config.filter.{{ name }}:
+{% if ( 'enabled' in options and options.enabled ) or ('enabled' not in options ) %}
+    file.managed:
+        - name: {{ fail2ban.prefix }}/etc/fail2ban/filter.d/{{ name }}.local
+        - source: {{ fail2ban_filters }}
+        - user: {{ fail2ban.user|default('root') }}
+        - group: {{ fail2ban.group|default('root') }}
+        - mode: '{{ fail2ban.mode|default("644")}}'
+        - template: jinja
+        - watch_in:
+          - service: {{ fail2ban.service }}
+        - context:
+            config: {{ options.config|yaml }}
+{% elif 'enabled' in options and not options.enabled %}
+    file.absent:
+        - name: {{ fail2ban.prefix }}/etc/fail2ban/filter.d/{{ name }}.local
+{% endif %}
+{% endfor %}

--- a/fail2ban/ng/files/config.jinja
+++ b/fail2ban/ng/files/config.jinja
@@ -1,0 +1,26 @@
+#
+# This file is managed by salt. Do not edit by hand.
+#
+{% macro print_config(name, value) %}
+    {%- set name_length = name|length %}
+    {%- if value is string %}
+{{ name }} = {{ value }}
+    {%- elif value is number %}
+{{ name }} = {{ value }}
+    {%- else %}
+    {#- Since strings are also sequences, there's no way to explicitly test for lists #}
+{{ name }} = {{ value|first }}
+        {%- if value|length > 1 %}
+            {%- for item in value[1:] %}
+{{ item|indent(width=name_length + 3, indentfirst=True) }}
+            {%- endfor %}
+        {%- endif %}
+    {%- endif %}
+{%- endmacro %}
+
+{%- for section, section_data in config|dictsort %}
+[{{section}}]
+{%- for name, value in section_data|dictsort %}
+{{- print_config(name, value) }}
+{%- endfor %}
+{% endfor %}

--- a/fail2ban/ng/init.sls
+++ b/fail2ban/ng/init.sls
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+include:
+    - fail2ban.ng.install
+    - fail2ban.ng.config
+    - fail2ban.ng.service

--- a/fail2ban/ng/install.sls
+++ b/fail2ban/ng/install.sls
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+{% from "fail2ban/ng/map.jinja" import fail2ban with context %}
+
+fail2ban.ng.install:
+  pkg.installed:
+    - name: {{ fail2ban.package }}

--- a/fail2ban/ng/map.jinja
+++ b/fail2ban/ng/map.jinja
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# vim: ft=jinja
+
+{% set os_family_map = salt['grains.filter_by']({
+    'FreeBSD': {
+        'package': 'py27-fail2ban',
+        'service': 'fail2ban',
+        'prefix': '/usr/local',
+    },
+    'Gentoo': {
+        'package': 'net-analyzer/fail2ban',
+        'service': 'fail2ban',
+        'prefix': '',
+    },
+    'default': {
+        'package': 'fail2ban',
+        'service': 'fail2ban',
+        'prefix': '',
+        'user': 'root',
+        'group': 'root',
+        'mode': '644',
+    },
+}, merge=salt['pillar.get']('fail2ban:lookup')) %}
+
+{% set fail2ban = salt['pillar.get'](
+        'fail2ban:ng',
+        default=os_family_map,
+        merge=True
+    )
+%}

--- a/fail2ban/ng/service.sls
+++ b/fail2ban/ng/service.sls
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+{% from "fail2ban/ng/map.jinja" import fail2ban with context %}
+
+fail2ban.ng.service:
+{% if ( 'enabled' in fail2ban and fail2ban.enabled ) or ('enabled' not in fail2ban ) %}
+    service.running:
+        - name: {{ fail2ban.service }}
+        - enable: True
+        - require:
+            - pkg: {{ fail2ban.package }}
+{% elif 'enabled' in fail2ban and not fail2ban.enabled %}
+    service.dead:
+        - name: {{ fail2ban.service }}
+        - enable: False
+{% endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -43,11 +43,21 @@ fail2ban:
 
     # fail2ban.local
     config:
+
+      # FTP-style
+      source_path: salt://path-to-fail2ban-file
+
+      # Template-style
       loglevel: ERROR
       logtarget: /var/log/fail2ban.log
 
     # jail.local
       jails:
+
+        # FTP-style
+        source_path: salt://path-to-jail-file
+
+        # Template-style
         DEFAULT:
           ignoreip: 127.0.0.1
           bantime: 600
@@ -68,6 +78,8 @@ fail2ban:
 
     # action.d
     actions:
+
+      # Template-style
       csf-ip-deny:
         enabled: True # OPTIONAL, default True; if False, the action.d/csf-ip-deny.local action will be deleted
         config:
@@ -75,11 +87,22 @@ fail2ban:
             actionban: csf -d <ip> Added by Fail2Ban for <name>
             actionunban: csf -dr <ip>
 
+      # FTP-style
+      test-action:
+        config:
+          source_path: salt://path-to-action-file
+
     # filter.d
     filters:
+
+      # Template-style
       nginx-noscript:
         enabled: True # OPTIONAL, default True; if False, the filter.d/nginx-noscript.local will be deleted
         config:
           Definition:
             failregex: <HOST>.*(GET|POST).*(\.php|\.asp|\.exe|\.pl|\.cgi|\.scgi).*
 
+      # FTP-style
+      test-filter:
+        config:
+          source_path: salt://path-to-filter-file

--- a/pillar.example
+++ b/pillar.example
@@ -32,3 +32,54 @@ fail2ban:
       nginx-noscript:
         Definition:
           failregex: <HOST>.*(GET|POST).*(\.php|\.asp|\.exe|\.pl|\.cgi|\.scgi).*
+
+  #
+  # New NG states
+  #
+  ng:
+    lookup:
+      prefix: '/opt'
+      package: 'fail2ban-new-package'
+
+    # fail2ban.local
+    config:
+      loglevel: ERROR
+      logtarget: /var/log/fail2ban.log
+
+    # jail.local
+      jails:
+        DEFAULT:
+          ignoreip: 127.0.0.1
+          bantime: 600
+        ssh:
+          actions: iptables[name=SSH, port=ssh, protocol=tcp]
+          enabled: 'true'
+          filter: sshd
+          logpath: /var/log/auth.log
+          maxretry: 6
+          port: ssh
+        ssh_ddos:
+          action: iptables[name=SSH, port=ssh, protocol=tcp]
+          enabled: 'true'
+          filter: sshd-ddos
+          logpath: /var/log/auth.log
+          maxretry: 6
+          port: ssh
+
+    # action.d
+    actions:
+      csf-ip-deny:
+        enabled: True # OPTIONAL, default True; if False, the action.d/csf-ip-deny.local action will be deleted
+        config:
+          Definition:
+            actionban: csf -d <ip> Added by Fail2Ban for <name>
+            actionunban: csf -dr <ip>
+
+    # filter.d
+    filters:
+      nginx-noscript:
+        enabled: True # OPTIONAL, default True; if False, the filter.d/nginx-noscript.local will be deleted
+        config:
+          Definition:
+            failregex: <HOST>.*(GET|POST).*(\.php|\.asp|\.exe|\.pl|\.cgi|\.scgi).*
+


### PR DESCRIPTION
Added new `ng` states with some improvements:
- fail2ban service can be enabled/disabled adding an option (see readme; `enabled` option)
- config, jails, actions and filters can upload it configuration (see readme; `source_path` option)
- actions and filters can be deleted on demand (see readme; `enabled` option)
- lookup, config, jails, actions and filters are at the same section level (see readme)