### PR TITLE
feat(yamllint): include for this repo and apply rules throughout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 ---
 stages:
   - test
-  - commitlint
+  - lint
   - name: release
     if: branch = master AND type != pull_request
 
@@ -45,16 +45,21 @@ script:
 
 jobs:
   include:
-    # Define the commitlint stage
-    - stage: commitlint
+    # Define the `lint` stage (runs `yamllint` and `commitlint`)
+    - stage: lint
       language: node_js
       node_js: lts/*
       before_install: skip
       script:
+        # Install and run `yamllint`
+        - pip install --user yamllint
+        # yamllint disable-line rule:line-length
+        - yamllint -s . .yamllint pillar.example
+        # Install and run `commitlint`
         - npm install @commitlint/config-conventional -D
         - npm install @commitlint/travis-cli -D
         - commitlint-travis
-    # Define the release stage that runs semantic-release
+    # Define the release stage that runs `semantic-release`
     - stage: release
       language: node_js
       node_js: lts/*

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+# Extend the `default` configuration provided by `yamllint`
+extends: default
+
+# Files to ignore completely
+# 1. All YAML files under directory `node_modules/`, introduced during the Travis run
+ignore: |
+  node_modules/
+
+rules:
+  line-length:
+    # Increase from default of `80`
+    # Based on https://github.com/PyCQA/flake8-bugbear#opinionated-warnings (`B950`)
+    max: 88

--- a/pillar.example
+++ b/pillar.example
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 fail2ban:
   lookup:
     config:
@@ -81,7 +84,9 @@ fail2ban:
 
       # Template-style
       csf-ip-deny:
-        enabled: True # OPTIONAL, default True; if False, the action.d/csf-ip-deny.local action will be deleted
+        # OPTIONAL, default true;
+        # if false, the action.d/csf-ip-deny.local action will be deleted
+        enabled: true
         config:
           Definition:
             actionban: csf -d <ip> Added by Fail2Ban for <name>
@@ -97,7 +102,9 @@ fail2ban:
 
       # Template-style
       nginx-noscript:
-        enabled: True # OPTIONAL, default True; if False, the filter.d/nginx-noscript.local will be deleted
+        # OPTIONAL, default true;
+        # if false, the filter.d/nginx-noscript.local will be deleted
+        enabled: true
         config:
           Definition:
             failregex: <HOST>.*(GET|POST).*(\.php|\.asp|\.exe|\.pl|\.cgi|\.scgi).*

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 name: default
 title: fail2ban formula
 maintainer: SaltStack Formulas


### PR DESCRIPTION
* Semi-automated using `ssf-formula` (v0.5.0)
* Fix errors shown below:

```bash
fail2ban-formula$ $(grep "\- yamllint" .travis.yml | sed -e "s:^\s\+-\s\(.*\):\1:")
pillar.example
  1:1       warning  missing document start "---"  (document-start)
  84:18     warning  truthy value should be one of [false, true]  (truthy)
  84:23     warning  too few spaces before comment  (comments)
  84:89     error    line too long (111 > 88 characters)  (line-length)
  100:18    warning  truthy value should be one of [false, true]  (truthy)
  100:23    warning  too few spaces before comment  (comments)
  100:89    error    line too long (107 > 88 characters)  (line-length)
```

---

Refer back to: https://github.com/saltstack-formulas/template-formula/pull/159#issue-305203039.